### PR TITLE
[ready] show warning if no currency supported

### DIFF
--- a/admin/controller/extension/payment/remitano.php
+++ b/admin/controller/extension/payment/remitano.php
@@ -96,6 +96,10 @@ class ControllerExtensionPaymentRemitano extends Controller {
 			$data['payment_remitano_sort_order'] = $this->config->get('payment_remitano_sort_order');
 		}
 
+		$this->load->model('extension/payment/remitano');
+		$data['has_supported_currency'] = $this->model_extension_payment_remitano->hasSupportedCurrency();
+		$data['text_does_not_have_supported_currency'] = $this->language->get('text_does_not_have_supported_currency');
+
 		$data['header'] = $this->load->controller('common/header');
 		$data['column_left'] = $this->load->controller('common/column_left');
 		$data['footer'] = $this->load->controller('common/footer');

--- a/admin/language/en-gb/extension/payment/remitano.php
+++ b/admin/language/en-gb/extension/payment/remitano.php
@@ -9,6 +9,7 @@ $_['text_edit'] = 'Edit Remitano Payment Gateway information';
 $_['text_remitano'] = '<a target="_BLANK" href="https://remitano.com/payment_gateway"><img src="view/image/payment/remitano.png" alt="Remitano Payment Gateway" title="Remitano Payment Gateway" style="border: 1px solid #EEEEEE;width:94px;height:25px" /></a>';
 $_['text_authorization'] = 'Authorization';
 $_['text_sale'] = 'Sale';
+$_['text_does_not_have_supported_currency'] = 'Your opencart website does not have any currency supported by Remitano Payment Gateway!';
 
 // Entry
 $_['entry_key'] = 'Key';

--- a/admin/model/extension/payment/remitano.php
+++ b/admin/model/extension/payment/remitano.php
@@ -1,0 +1,15 @@
+<?php
+class ModelExtensionPaymentRemitano extends Model {
+	public function hasSupportedCurrency() {
+		$this->load->model('localisation/currency');
+		$oc_currencies = array_column($this->model_localisation_currency->getCurrencies(), 'code');
+
+		$remitano_supported_currencies = array("AED", "ARS", "AUD", "BND", "BOB", "BRL", "BYN", "CAD", "CDF", "CFA",
+						"CHF", "CNY", "COP", "DKK", "DZD", "EUR", "GBP", "GHS", "HKD", "IDR", "ILS", "INR", "JPY",
+						"KES", "KRW", "LAK", "MMK", "MXN", "MYR", "NAD", "NGN", "NOK", "NPR", "NZD", "OMR", "PEN",
+						"PHP", "PKR", "PLN", "QAR", "RUB", "RWF", "SEK", "SGD", "THB", "TRY", "TWD", "TZS", "UAH",
+						"UGX", "USD", "VES", "VND", "XAF", "ZAR", "ZMW", "USDT");
+
+		return count(array_intersect($oc_currencies, $remitano_supported_currencies)) > 0;
+	}
+}

--- a/admin/view/template/extension/payment/remitano.twig
+++ b/admin/view/template/extension/payment/remitano.twig
@@ -19,6 +19,9 @@
       <button type="button" class="close" data-dismiss="alert">&times;</button>
     </div>
     {% endif %}
+    {% if has_supported_currency == false %}
+    <div class="alert alert-danger alert-dismissible"><i class="fa fa-exclamation-circle"></i> {{ text_does_not_have_supported_currency }}</div>
+    {% endif %}
     <div class="panel panel-default">
       <div class="panel-heading">
         <h3 class="panel-title"><i class="fa fa-pencil"></i> {{ text_edit }}</h3>

--- a/catalog/language/en-gb/extension/payment/remitano.php
+++ b/catalog/language/en-gb/extension/payment/remitano.php
@@ -1,5 +1,5 @@
 <?php
 // Text
 $_['text_title']	= 'Remitano Payment Gateway';
-$_['text_does_not_support_currency']	= 'Remitano payment gateway does not support this currency.';
+$_['text_does_not_support_currency']	= 'Remitano Payment Gateway does not support this currency.';
 $_['text_testmode']	= 'Warning: The payment gateway is in \'Sandbox Mode\'. Your account will not be charged.';

--- a/install.xml
+++ b/install.xml
@@ -4,5 +4,5 @@
     <name>Remitano Payment Gateway</name>
     <version>1.1</version>
     <author>remitanoofficial</author>
-    <link>http://www.opencart.com</link>
+    <link>https://developers.remitano.com/docs/payment-gateway/plugins/opencart</link>
 </modification>


### PR DESCRIPTION
Phần warning ở admin page sẽ trông như vầy
![Screen Shot 2021-08-02 at 11 41 00](https://user-images.githubusercontent.com/16667581/127835958-80ae09d1-d1d5-4fd3-9893-39c1b41fcca0.png)

Việc auto disabled nếu không có currency support thì em cũng đã thử và nó mang lại trải nghiệm khá kỳ cục vì sau khi chọn enabled, saved xong thì vẫn thấy disabled, em nghĩ show warning rõ ràng như trên là đủ ạ.

Về phần show warning luôn cho người mua ở phần lựa chọn phương thức thanh toán là không khả thi ạ vì nó nằm ngoài code base của extension. Mình cũng đã show warning ngay sau step đó và ẩn nút confirm pay nên em nghĩ vẫn ok.